### PR TITLE
feat: add manual entry forms and timeline

### DIFF
--- a/web/src/components/FeedForm.jsx
+++ b/web/src/components/FeedForm.jsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { addFeedEvent } from '../api';
+
+export default function FeedForm({ onAdd }) {
+  const [form, setForm] = useState({ start_time: '', end_time: '', amount: '', notes: '' });
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const start = new Date(form.start_time);
+    const end = form.end_time ? new Date(form.end_time) : null;
+    const amount = form.amount ? parseFloat(form.amount) : null;
+    if (!form.start_time || isNaN(start)) {
+      alert('Start time is required');
+      return;
+    }
+    if (end && end <= start) {
+      alert('End time must be after start');
+      return;
+    }
+    if (amount !== null && amount <= 0) {
+      alert('Amount must be positive');
+      return;
+    }
+    const payload = {
+      start_time: start.toISOString(),
+      end_time: end ? end.toISOString() : null,
+      amount,
+      notes: form.notes
+    };
+    addFeedEvent(payload)
+      .then(() => {
+        setForm({ start_time: '', end_time: '', amount: '', notes: '' });
+        onAdd && onAdd();
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <div className="form-card">
+      <h2>Add Feed</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="datetime-local"
+          value={form.start_time}
+          onChange={e => setForm({ ...form, start_time: e.target.value })}
+          required
+        />
+        <input
+          type="datetime-local"
+          value={form.end_time}
+          onChange={e => setForm({ ...form, end_time: e.target.value })}
+        />
+        <input
+          type="number"
+          step="0.1"
+          value={form.amount}
+          onChange={e => setForm({ ...form, amount: e.target.value })}
+          placeholder="Amount"
+        />
+        <textarea
+          value={form.notes}
+          onChange={e => setForm({ ...form, notes: e.target.value })}
+          placeholder="Notes"
+        />
+        <button type="submit">Save</button>
+      </form>
+    </div>
+  );
+}
+

--- a/web/src/components/SleepForm.jsx
+++ b/web/src/components/SleepForm.jsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { addSleepEvent } from '../api';
+
+export default function SleepForm({ onAdd }) {
+  const [form, setForm] = useState({ start_time: '', end_time: '', notes: '' });
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const start = new Date(form.start_time);
+    const end = form.end_time ? new Date(form.end_time) : null;
+    if (!form.start_time || isNaN(start)) {
+      alert('Start time is required');
+      return;
+    }
+    if (end && end <= start) {
+      alert('End time must be after start');
+      return;
+    }
+    const payload = {
+      start_time: start.toISOString(),
+      end_time: end ? end.toISOString() : null,
+      notes: form.notes
+    };
+    addSleepEvent(payload)
+      .then(() => {
+        setForm({ start_time: '', end_time: '', notes: '' });
+        onAdd && onAdd();
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <div className="form-card">
+      <h2>Add Sleep</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="datetime-local"
+          value={form.start_time}
+          onChange={e => setForm({ ...form, start_time: e.target.value })}
+          required
+        />
+        <input
+          type="datetime-local"
+          value={form.end_time}
+          onChange={e => setForm({ ...form, end_time: e.target.value })}
+        />
+        <textarea
+          value={form.notes}
+          onChange={e => setForm({ ...form, notes: e.target.value })}
+          placeholder="Notes"
+        />
+        <button type="submit">Save</button>
+      </form>
+    </div>
+  );
+}
+

--- a/web/src/components/Timeline.jsx
+++ b/web/src/components/Timeline.jsx
@@ -1,0 +1,18 @@
+export default function Timeline({ events }) {
+  return (
+    <div className="timeline-card">
+      <h2>Timeline</h2>
+      <ul className="timeline">
+        {events.map(ev => (
+          <li key={`${ev.type}-${ev.id}`}>
+            <strong>{ev.type === 'sleep' ? 'Sleep' : 'Feed'}{ev.type === 'feed' && ev.amount ? ` (${ev.amount})` : ''}</strong>
+            {' '}
+            {new Date(ev.start_time).toLocaleString()}
+            {ev.end_time ? ` - ${new Date(ev.end_time).toLocaleString()}` : ''}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/web/src/pages/Logs.jsx
+++ b/web/src/pages/Logs.jsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react';
-import { getSleepEvents, getFeedEvents, addSleepEvent, addFeedEvent } from '../api';
+import { getSleepEvents, getFeedEvents } from '../api';
+import SleepForm from '../components/SleepForm';
+import FeedForm from '../components/FeedForm';
+import Timeline from '../components/Timeline';
 import './pages.css';
 
 export default function Logs() {
   const [sleepEvents, setSleepEvents] = useState([]);
   const [feedEvents, setFeedEvents] = useState([]);
-  const [sleepForm, setSleepForm] = useState({ start_time: '', end_time: '', notes: '' });
-  const [feedForm, setFeedForm] = useState({ start_time: '', end_time: '', amount: '', notes: '' });
 
   const load = () => {
     getSleepEvents().then(setSleepEvents).catch(() => {});
@@ -15,53 +16,17 @@ export default function Logs() {
 
   useEffect(() => { load(); }, []);
 
-  const handleSleepSubmit = (e) => {
-    e.preventDefault();
-    addSleepEvent(sleepForm).then(() => {
-      setSleepForm({ start_time: '', end_time: '', notes: '' });
-      load();
-    }).catch(() => {});
-  };
-
-  const handleFeedSubmit = (e) => {
-    e.preventDefault();
-    addFeedEvent(feedForm).then(() => {
-      setFeedForm({ start_time: '', end_time: '', amount: '', notes: '' });
-      load();
-    }).catch(() => {});
-  };
+  const events = [
+    ...sleepEvents.map(e => ({ ...e, type: 'sleep' })),
+    ...feedEvents.map(e => ({ ...e, type: 'feed' }))
+  ].sort((a, b) => new Date(a.start_time) - new Date(b.start_time));
 
   return (
     <div className="logs">
-      <div className="form-card">
-        <h2>Add Sleep</h2>
-        <form onSubmit={handleSleepSubmit}>
-          <input type="datetime-local" value={sleepForm.start_time} onChange={e => setSleepForm({ ...sleepForm, start_time: e.target.value })} required />
-          <input type="datetime-local" value={sleepForm.end_time} onChange={e => setSleepForm({ ...sleepForm, end_time: e.target.value })} />
-          <textarea value={sleepForm.notes} onChange={e => setSleepForm({ ...sleepForm, notes: e.target.value })} placeholder="Notes" />
-          <button type="submit">Save</button>
-        </form>
-        <ul>
-          {sleepEvents.map(e => (
-            <li key={e.id}>{e.start_time} - {e.end_time}</li>
-          ))}
-        </ul>
-      </div>
-      <div className="form-card">
-        <h2>Add Feed</h2>
-        <form onSubmit={handleFeedSubmit}>
-          <input type="datetime-local" value={feedForm.start_time} onChange={e => setFeedForm({ ...feedForm, start_time: e.target.value })} required />
-          <input type="datetime-local" value={feedForm.end_time} onChange={e => setFeedForm({ ...feedForm, end_time: e.target.value })} />
-          <input type="number" step="0.1" value={feedForm.amount} onChange={e => setFeedForm({ ...feedForm, amount: e.target.value })} placeholder="Amount" />
-          <textarea value={feedForm.notes} onChange={e => setFeedForm({ ...feedForm, notes: e.target.value })} placeholder="Notes" />
-          <button type="submit">Save</button>
-        </form>
-        <ul>
-          {feedEvents.map(e => (
-            <li key={e.id}>{e.start_time} - {e.amount}</li>
-          ))}
-        </ul>
-      </div>
+      <SleepForm onAdd={load} />
+      <FeedForm onAdd={load} />
+      <Timeline events={events} />
     </div>
   );
 }
+

--- a/web/src/pages/pages.css
+++ b/web/src/pages/pages.css
@@ -35,3 +35,20 @@ input, textarea, button {
   font-size: 1.2rem;
   padding: 0.75rem;
 }
+
+.timeline-card {
+  flex: 1 1 100%;
+  background: #f5f5f5;
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+.timeline {
+  list-style: none;
+  padding: 0;
+}
+
+.timeline li {
+  margin-bottom: 0.5rem;
+}
+


### PR DESCRIPTION
## Summary
- add React components to manually log naps and feedings with validation and timezone conversion
- provide timeline view combining sleep and feed events
- style logs page with timeline section

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1b9f982b0832db41d4b7876872dc4